### PR TITLE
Pass ssl configuration options to redix

### DIFF
--- a/lib/redix_clustered/options.ex
+++ b/lib/redix_clustered/options.ex
@@ -3,7 +3,7 @@ defmodule RedixClustered.Options do
   @pool_size "pool_size"
   @default_pool_size 1
   @redix_opts "redix_opts"
-  @redix_keys [:host, :port, :username, :password, :timeout]
+  @redix_keys [:host, :port, :username, :password, :timeout, :ssl]
   @redix_request_opts "redix_request_opts"
   @redix_request_key :request_opts
 

--- a/lib/redix_clustered/options.ex
+++ b/lib/redix_clustered/options.ex
@@ -3,7 +3,7 @@ defmodule RedixClustered.Options do
   @pool_size "pool_size"
   @default_pool_size 1
   @redix_opts "redix_opts"
-  @redix_keys [:host, :port, :username, :password, :timeout, :ssl]
+  @redix_keys [:host, :port, :username, :password, :timeout, :ssl, :socket_opts]
   @redix_request_opts "redix_request_opts"
   @redix_request_key :request_opts
 

--- a/test/redix_clustered/options_test.exs
+++ b/test/redix_clustered/options_test.exs
@@ -90,4 +90,18 @@ defmodule RedixClustered.OptionsTest do
     assert pool_size("#{@name}2") == 5
     assert namespace("#{@name}2") == nil
   end
+
+  test "passes ssl options to redix" do
+    opts = [
+      name: @name,
+      host: @host,
+      port: @port,
+      ssl: true,
+      socket_opts: [ verify: :no_verify ],
+    ]
+
+    start_supervised!({RedixClustered, opts})
+
+    assert redix_opts(@name) == [host: @host, port: @port, ssl: true, socket_opts: [ verify: :no_verify ]]
+  end
 end


### PR DESCRIPTION
Passing these options is required to support a redis cluster with SSL enabled.